### PR TITLE
Work around httplib2 connection errors (fixes #26)

### DIFF
--- a/sccresources/requirements.txt
+++ b/sccresources/requirements.txt
@@ -1,4 +1,5 @@
 Django==2.0.10
+certifi==2016.9.26  # https://github.com/elastic/elasticsearch-py/issues/469
 django-background-tasks==1.1.13
 django-compat==1.0.15
 django-dotenv==1.4.2
@@ -8,6 +9,9 @@ google-auth==1.6.1
 google-auth-httplib2==0.0.3
 googlemaps==2.5.1
 gunicorn==19.9.0
+# maybe order matters for these next two
+urllib3[secure]==1.24.1
+httplib2shim==0.0.3
 icalendar==4.0.1
 phonenumbers==8.9.6
 pyRFC3339==1.0

--- a/sccresources/sccalendar/google_credentials_auth.py
+++ b/sccresources/sccalendar/google_credentials_auth.py
@@ -1,4 +1,7 @@
 import os
+import httplib2shim
+# workaround for connection errors see https://github.com/thefreeguide/sccountyresources/issues/26
+httplib2shim.patch()  # NOQA
 
 from google.oauth2 import service_account
 from googleapiclient.discovery import build


### PR DESCRIPTION
By using a new library we work around whatever errors the old API was bringing up.