### PR TITLE
Prevent navbar from wrapping (fixes #35)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ __pycache__
 servicekey.json
 app.yaml
 app.yml
-
+/sccresources/static

--- a/sccresources/sccalendar/templates/base_generic.html
+++ b/sccresources/sccalendar/templates/base_generic.html
@@ -33,7 +33,7 @@
   <!-- Navigation -->
   <nav class="navbar navbar-expand-lg navbar-dark fixed-top" id="mainNav">
     <div class="container">
-      <a class="navbar-brand" href="/calendar/">The Santa Cruz Free Guide</a>
+      <a class="navbar-brand" href="/calendar/">The Free Guide</a>
       <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
         Menu
         <i class="fas fa-bars"></i>


### PR DESCRIPTION
This prevents the navbar from wrapping on small screens.

Also 5d7956e1 ignores the global static dir so I don't get git confused when I run `python manage.py collectstatic`