### PR TITLE
Setup maps API key for more secure deployment

### DIFF
--- a/sccresources/sccalendar/google_credentials_auth.py
+++ b/sccresources/sccalendar/google_credentials_auth.py
@@ -27,7 +27,7 @@ def get_google_api_key(dest):
         raise ValueError("dest must be 'server' or 'client'")
     try:
         # For local deployment, only one key needs to be used
-        return os.environ[f'GOOGLE_MAPS_KEY']
+        return os.environ['GOOGLE_MAPS_KEY']
     except KeyError:
         pass
     try:

--- a/sccresources/sccalendar/google_credentials_auth.py
+++ b/sccresources/sccalendar/google_credentials_auth.py
@@ -17,12 +17,23 @@ def get_google_service_credentials():
         raise ValueError('Set GOOGLE_SERVICE_KEY to allow Google API access')
 
 
-def get_google_api_key():
-    """Return api key or raise ValueError"""
+def get_google_api_key(dest):
+    """
+    Return api key or raise ValueError
+
+    dest may be 'server' or 'client'
+    """
+    if dest not in ('server', 'client'):
+        raise ValueError("dest must be 'server' or 'client'")
     try:
-        return os.environ['GOOGLE_MAPS_KEY']
+        # For local deployment, only one key needs to be used
+        return os.environ[f'GOOGLE_MAPS_KEY']
     except KeyError:
-        raise ValueError('Set GOOGLE_MAPS_KEY to allow Google API access')
+        pass
+    try:
+        return os.environ[f'GOOGLE_MAPS_KEY_{dest.upper()}']
+    except KeyError:
+        raise ValueError(f'Set GOOGLE_MAPS_KEY[_{dest.upper()}] to allow Google API access')
 
 
 credentials = service_account.Credentials.from_service_account_file(

--- a/sccresources/sccalendar/google_maps.py
+++ b/sccresources/sccalendar/google_maps.py
@@ -46,7 +46,7 @@ class GoogleMaps:
     service: Calendar connection object used to request maps data
     """
 
-    def __init__(self, key: str = get_google_api_key()) -> None:
+    def __init__(self, key: str = get_google_api_key('server')) -> None:
         """
         Creates new GoogleMaps object
         :param key: The google maps API key that provides access to the full suite of APIs

--- a/sccresources/sccalendar/templates/search.html
+++ b/sccresources/sccalendar/templates/search.html
@@ -132,7 +132,7 @@
             * The callback parameter executes the initMap() function
           -->
           <script async defer
-          src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAowLhX_nqZQhUuPjJ0qSORBrlhUV7SB7E&callback=initMap">
+          src="https://maps.googleapis.com/maps/api/js?key={{ maps_key }}&callback=initMap">
           </script>
         </div>
       </div>

--- a/sccresources/sccalendar/views.py
+++ b/sccresources/sccalendar/views.py
@@ -191,9 +191,13 @@ def search(request, year=None, month=None, day=None, timespan=None):  # noqa: C9
                 jsongeocode = response.read()
                 jsongeocode = json.loads(jsongeocode)
                 if jsongeocode['status'] == "OK":
-                    event.latlng = [jsongeocode['results'][0]['geometry']['location']['lat'], jsongeocode['results'][0]['geometry']['location']['lng']]
+                    event.latlng = [
+                        jsongeocode['results'][0]['geometry']['location']['lat'],
+                        jsongeocode['results'][0]['geometry']['location']['lng']
+                    ]
                 else:
-                    logger.error("Was unable to geocode event %s, api status was %s", event.summary, jsongeocode['status'])
+                    logger.error("Was unable to geocode event %s, api status was %s",
+                                 event.summary, jsongeocode['status'])
                     event.location = None
                     event.latlng = "NO_ADDRESS"
             else:
@@ -211,12 +215,15 @@ def search(request, year=None, month=None, day=None, timespan=None):  # noqa: C9
     return render(
         request,
         'search.html',
-        context={'origin': request.GET.get('locations', ''),
-                 'service': request.GET.get('services'),
-                 'day_events': day_events,
-                 'day_name': day_name,
-                 'next_date': time_next_date,
-                 'prev_date': time_prev_date}
+        context={
+            'origin': request.GET.get('locations', ''),
+            'service': request.GET.get('services'),
+            'day_events': day_events,
+            'day_name': day_name,
+            'next_date': time_next_date,
+            'prev_date': time_prev_date,
+            'maps_key': get_google_api_key()
+        }
     )
 
 
@@ -491,7 +498,7 @@ def events(request):
             data_to_add = StaticEvent.objects.filter(category__exact=event_category).filter(area__exact=event_area)
             if data_to_add:
                 category_data.append(data_to_add)
-                
+
         area_data.append(category_data)
     return render(
         request,

--- a/sccresources/sccalendar/views.py
+++ b/sccresources/sccalendar/views.py
@@ -180,7 +180,7 @@ def search(request, year=None, month=None, day=None, timespan=None):  # noqa: C9
                   'singleEvents': True,
                   'orderBy': "startTime"}
     day_events = api_call(services, locations, api_params)
-    key = get_google_api_key()
+    key = get_google_api_key('server')
     if day_events:
         for event in day_events:
             # Geocode event location and check to make sure it gets a correct result. If not, pass to array as if it did not have address
@@ -222,7 +222,7 @@ def search(request, year=None, month=None, day=None, timespan=None):  # noqa: C9
             'day_name': day_name,
             'next_date': time_next_date,
             'prev_date': time_prev_date,
-            'maps_key': get_google_api_key()
+            'maps_key': get_google_api_key('client')
         }
     )
 
@@ -469,7 +469,7 @@ def details(request, service=None, event_id=None):
             'id': event_id,
             'service': service,
             'origin': origin,
-            'api_key': get_google_api_key(),
+            'api_key': get_google_api_key('client'),
             'contact_form': form
         })
 


### PR DESCRIPTION
Now during deployment, two separate maps keys are needed and each should have different restrictions:
- `GOOGLE_MAPS_KEY_SERVICE` should restrict APIs, but not URLs
- `GOOGLE_MAPS_KEY_CLIENT` should restrict APIs and also restrict URLs to the host domain.